### PR TITLE
Fix for pip install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 github3.py==0.9.6
-pkg-resources==0.0.0
 requests==2.12.5
 uritemplate==3.0.0
 uritemplate.py==3.0.2


### PR DESCRIPTION
Fixes error reported as "Could not find a version that satisfies the requirement pkg-resources==0.0.0"
Which appears to be related to this bug: https://github.com/pypa/pip/issues/4022